### PR TITLE
TGpImage: When creating from png, using tempfile, I suggest removing FileExists check

### DIFF
--- a/source/GDIPL2A.pas
+++ b/source/GDIPL2A.pas
@@ -293,8 +293,6 @@ var
 //    Buffer: array [0..511] of WideChar;
 begin
   inherited Create;
-  if not FileExists(FileName) then
-    raise EGDIPlus.Create(Format('Image file %s not found.', [FileName]));
   err := GdipLoadImageFromFile(PWideChar(FileName), fHandle);
   if err <> 0 then
     raise EGDIPlus.Create(Format('Can''t load image file %s.', [FileName]));


### PR DESCRIPTION
Hello, we are using the HtmlViewer11 branch in D6, to power an Isapi extension. We discovered a problem with png files when using HtmlViewer to generate pdf:

When using png and gdi+, a tempfile is used. TGpImage.Create checks for the existence of the file with FileExists. But that doesn't work with the default file permission setup for IUSR in Win7 or Win2003.

So I suggest removing that check. If the file does not exist, an exception will be raised after the GdipLoadImageFromFile anyway.
## ::tor

Tor Helland, developer,
Gitek AS
