### PR TITLE
Moved code using csNeedsBorderPaint into Delphi 7 ifdef.

### DIFF
--- a/source/htmlview.pas
+++ b/source/htmlview.pas
@@ -696,9 +696,9 @@ begin
 //  BorderPanel.ParentCtl3D := False;
 {$ifdef delphi7_plus}
   BorderPanel.ParentBackground := False;
-{$endif}
-{$endif}
   BorderPanel.ControlStyle := BorderPanel.ControlStyle + [csNeedsBorderPaint];
+{$endif}
+{$endif}
   BorderPanel.Parent := Self;
 
   PaintPanel := TPaintPanel.CreateIt(Self, Self);


### PR DESCRIPTION
Didn't compile on Delphi 6.

Is it correct to put the line into the delphi7_plus ifdef inside "ifndef LCL", or is csNeedsBorderPaint also available in LCL?
