### PR TITLE
Fixed XE6 MainDemo compile

### DIFF
--- a/Demos/Main Demos/Htmlabt.pas
+++ b/Demos/Main Demos/Htmlabt.pas
@@ -122,6 +122,9 @@ begin
 {$ifdef Ver260}
     'Delphi XE5'
 {$endif}
+{$ifdef Ver270}
+    'Delphi XE6'
+{$endif}
 {$ifdef LCL}
     'Lazarus ' + lcl_version
 {$endif}


### PR DESCRIPTION
About box did not have XE6 reference
