### PR TITLE
Issue 379: Support for type="disc|circle|square" for <ul>

### DIFF
--- a/source/HTMLSubs.pas
+++ b/source/HTMLSubs.pas
@@ -6460,11 +6460,17 @@ begin
           FListStyleType := lbNone
         else
           if Tmp = lbBlank then
-            case ListLevel mod 3 of
-              1: FListStyleType := lbDisc;
-              2: FListStyleType := lbCircle;
-              0: FListStyleType := lbSquare;
-            end;
+            case AIndexType of // type="disc|circle|square"
+              'd': FListStyleType := lbDisc;
+              'c': FListStyleType := lbCircle;
+              's': FListStyleType := lbSquare;
+            else
+              case ListLevel mod 3 of
+                1: FListStyleType := lbDisc;
+                2: FListStyleType := lbCircle;
+                0: FListStyleType := lbSquare;
+              end;
+            end;  
       end;
 
     OLSy:

--- a/source/ReadHTML.pas
+++ b/source/ReadHTML.pas
@@ -3725,8 +3725,15 @@ begin
          Index := T.Name[1];
       end;
     ULSy:
-      Plain := Attributes.Find(PlainSy, T)
-           or (Attributes.Find(TypeSy, T) and ((Lowercase(T.Name) = 'none') or (Lowercase(T.Name) = 'plain')));
+      begin
+        Plain := Attributes.Find(PlainSy, T)
+             or (Attributes.Find(TypeSy, T) and ((Lowercase(T.Name) = 'none') or (Lowercase(T.Name) = 'plain')));
+
+        if Attributes.Find(TypeSy, T) then
+          if LowerCase(T.Name) = 'disc' then  Index := 'd'
+          else if LowerCase(T.Name) = 'circle' then  Index := 'c'
+          else if LowerCase(T.Name) = 'square' then  Index := 's';
+      end;       
   end;
   SectionList.Add(Section, TagIndex);
   Section := nil;


### PR DESCRIPTION
I have implemented the support for type="disc|circle|square" for <ul>

I followed W3Schools as a guide and used JSFiddle to make sure that it works correctly.

This is deprecated in HTML5, so it is up to you whether you want to support it.
