### PR TITLE
+ Consider all #nnn char constants Wide for better portatibility (also r...

### DIFF
--- a/source/htmlcons.inc
+++ b/source/htmlcons.inc
@@ -200,6 +200,10 @@
 
   {$warn Symbol_Platform Off}
 
+  {$IFDEF UNICODE}
+    {$HIGHCHARUNICODE ON}  {make all #nn char constants Wide for better portatibility}
+  {$ENDIF}
+
   {$define OwnPaintPanelDoubleBuffering}
 
 {$endif}


### PR DESCRIPTION
...emoves Ansi<=>Wide conversion warnings)