### PR TITLE
fix 'Unable to find the component class "TBaseForm".'

### DIFF
--- a/Demos/Main Demos/demounit.pas
+++ b/Demos/Main Demos/demounit.pas
@@ -95,7 +95,7 @@ type
 {$ifdef UseTNT}
     TBaseForm = TTntForm;
 {$else}
-    TBaseForm = TForm;
+    TBaseForm = class(TForm);
 {$endif}
 
   { TForm1 }


### PR DESCRIPTION
fix 'Unable to find the component class "TBaseForm".' error when loading
main demo in lazarus 1.4/fpc 2.6.4