### PR TITLE
fix 'Unable to find the component class "TBaseForm".'

### DIFF
--- a/Demos/Main Demos/FDemUnit.pas
+++ b/Demos/Main Demos/FDemUnit.pas
@@ -92,7 +92,7 @@ type
 {$ifdef UseTNT}
     TBaseForm = TTntForm;
 {$else}
-    TBaseForm = TForm;
+    TBaseForm = class(TForm);
 {$endif}
 
   { TForm1 }


### PR DESCRIPTION
fix 'Unable to find the component class "TBaseForm".'  error when
loading frame demo in lazarus 1.4/fpc 2.6.4