### PR TITLE
Removed unneccessary dependency to FCL package.

### DIFF
--- a/package/FrameViewer09.lpk
+++ b/package/FrameViewer09.lpk
@@ -201,17 +201,13 @@
         <UnitName Value="UrlConn"/>
       </Item39>
     </Files>
-    <RequiredPkgs Count="3">
+    <RequiredPkgs Count="2">
       <Item1>
         <PackageName Value="printer4lazarus"/>
       </Item1>
       <Item2>
         <PackageName Value="LCL"/>
       </Item2>
-      <Item3>
-        <PackageName Value="FCL"/>
-        <MinVersion Major="1" Valid="True"/>
-      </Item3>
     </RequiredPkgs>
     <UsageOptions>
       <UnitPath Value="$(PkgOutDir)"/>


### PR DESCRIPTION
Lazarus by default adds this dependency to this package, while it is seldom needed.
By removing it, the package has a cleaner dependency tree and is more decoupled from unneeded libraries.