### PR TITLE
Fixed compiler warnings with Delphi 10.2.3

### DIFF
--- a/source/BuffConv.pas
+++ b/source/BuffConv.pas
@@ -1930,7 +1930,7 @@ active:
   kmax := 2;
   k := 0;
   base64count := 0;
-  i := 0; // valium for the compiler
+  {$IFNDEF Compiler32_Plus}i := 0;{$ENDIF} // valium for the compiler
   while c1 <> 0 do
   begin
     case c1 of

--- a/source/DitherUnit.pas
+++ b/source/DitherUnit.pas
@@ -1776,7 +1776,7 @@ begin
     if Source is ThtBitmap then
     begin
       FBitmap.WithTransparentMask := ThtBitmap(Source).WithTransparentMask;
-      FBitmap.Mask := ThtBitmap(Source).Mask;
+      FBitmap.BitmapMask := ThtBitmap(Source).BitmapMask;
     end;
     Result := FBitmap;
   end;

--- a/source/GDIPL2A.pas
+++ b/source/GDIPL2A.pas
@@ -353,6 +353,7 @@ begin
   if ((Image.Width <= 10) and (Width > Image.Width)) or ((Image.Height <= 10) and (Height > Image.Height)) then
     DrawSmallStretchedImage(Image, X, Y, Width, Height)
   else
+  begin
     //BG, 22.11.2016: calling GdipDrawImageRectI() tents to skip the right and bottom parts of the image.
     //GDICheck('ThtGpGraphics.DrawImage', GdipDrawImageRectI(fGraphics, Image.fHandle, X, Y, Width, Height));
     IW := Image.Width;
@@ -362,6 +363,7 @@ begin
     if Height < IH then
       Inc(IH);
     DrawImage(Image, X, Y, Width, Height, 0, 0, IW, IH);
+  end;
 end;
 
 procedure ThtGpGraphics.DrawSmallStretchedImage(Image: THtGPImage; X, Y, Width, Height: Integer);

--- a/source/HTMLGif2.pas
+++ b/source/HTMLGif2.pas
@@ -104,7 +104,7 @@ type
     procedure SetCurrentFrame(AFrame: Integer);
 
     procedure NextFrame(OldFrame: Integer);
-    procedure SetTransparent(AValue: Boolean);
+    procedure SetTransparent(AValue: Boolean); reintroduce;
 
   public
     ShowIt: Boolean;

--- a/source/HTMLSubs.pas
+++ b/source/HTMLSubs.pas
@@ -13066,7 +13066,7 @@ var
     NewCP := True;
     CPy := Y + LR.DrawY;  //Todo: Someone needs to find a sensible default value.
     CPx := X + LR.LineIndent;
-    CP1x := CPx;
+    {$IFNDEF Compiler32_Plus}CP1x := CPx;{$ENDIF}
     LR.DrawY := Y - LR.LineHt;
     LR.DrawXX := CPx;
     AdjustDrawRect( LR.DrawY, LR.DrawXX, LR.DrawWidth, LR.LineHt ); //>-- DZ 19.09.2012

--- a/source/HtmlGlobals.pas
+++ b/source/HtmlGlobals.pas
@@ -273,7 +273,7 @@ type
     procedure Assign(Source: TPersistent); override;
     procedure Draw(ACanvas: TCanvas; const Rect: TRect); override;
     procedure StretchDraw(ACanvas: TCanvas; const DestRect, SrcRect: TRect);
-    property Mask: TBitmap read GetMask write SetMask;
+    property BitmapMask: TBitmap read GetMask write SetMask;
     property WithTransparentMask: Boolean read FTransparent write SetTransparentMask;
   end;
 

--- a/source/HtmlGlobals.pas
+++ b/source/HtmlGlobals.pas
@@ -268,7 +268,7 @@ type
     FMask: TBitmap;
     FTransparent: boolean;
   public
-    constructor Create(WithTransparentMask: Boolean = False); overload;
+    constructor Create(WithTransparentMask: Boolean = False); reintroduce; overload;
     destructor Destroy; override;
     procedure Assign(Source: TPersistent); override;
     procedure Draw(ACanvas: TCanvas; const Rect: TRect); override;

--- a/source/HtmlGlobals.pas
+++ b/source/HtmlGlobals.pas
@@ -82,8 +82,8 @@ uses
 
 const
 {$ifndef LCL}
-  lcl_fullversion = 0;
-  fpc_fullversion = 0;
+  lcl_fullversion = Integer(0);
+  fpc_fullversion = Integer(0);
 {$endif}
 {$ifndef MSWindows}
   //Charsets defined in unit Windows:

--- a/source/HtmlImages.pas
+++ b/source/HtmlImages.pas
@@ -237,7 +237,7 @@ type
   private
     FGraphic: TGraphic;
     FImage: ThtBitmapImage;
-    procedure Construct; deprecated;
+    procedure Construct; // deprecated; // ToDo -oOwner: This method is deprecated and private for more than 3 years. Either remove the deprecated attribute or point out how to resolve the deprecated warning.
   protected
     function GetBitmap: TBitmap; override;
     function GetGraphic: TGraphic; override;

--- a/source/HtmlImages.pas
+++ b/source/HtmlImages.pas
@@ -486,7 +486,7 @@ function ConvertImage(Bitmap: ThtBitmap): ThtBitmap;
     SelectObject(DC, OldBmp);
     DeleteDC(DC);
     Result := ThtBitmap.Create(Bitmap.WithTransparentMask);
-    Result.Mask := Bitmap.Mask;
+    Result.BitmapMask := Bitmap.BitmapMask;
     Bitmap.Free;
     Result.Handle := Hnd;
     if (ColorBits = 8) and (Result.Palette = 0) then
@@ -881,7 +881,7 @@ var
         Bitmap.Handle := IconInfo.hbmColor;
         if Transparent <> itrLLCorner then
         begin
-          Bitmap.Mask.Handle := IconInfo.hbmMask;
+          Bitmap.BitmapMask.Handle := IconInfo.hbmMask;
           Transparent := itrIntrinsic;
         end;
       end;
@@ -958,14 +958,14 @@ begin
     if Bitmap <> nil then
     begin
       Mask := nil;
-      if Bitmap.Mask = nil then
+      if Bitmap.BitmapMask = nil then
         if Transparent = itrLLCorner then
           Mask := GetImageMask(Bitmap, False, 0);
       Bitmap := ConvertImage(Bitmap);
       if Mask <> nil then
       begin
         Bitmap.WithTransparentMask := True;
-        Bitmap.Mask := Mask;
+        Bitmap.BitmapMask := Mask;
         Mask.Free;
       end;
       Result := ThtBitmapImage.Create(Bitmap, Transparent);
@@ -2113,7 +2113,7 @@ begin
   inherited Create(Tr);
   Bitmap := AImage;
   OwnsBitmap := AOwnsBitmap;
-  Mask := AImage.Mask;
+  Mask := AImage.BitmapMask;
   OwnsMask := False;
 end;
 
@@ -2313,7 +2313,7 @@ end;
 //-- BG ---------------------------------------------------------- 09.04.2011 --
 function ThtGifImage.GetMask: TBitmap;
 begin
-  Result := Gif.Mask;
+  Result := Gif.BitmapMask;
 end;
 
 //-- BG ---------------------------------------------------------- 02.09.2015 --

--- a/source/UrlConn.pas
+++ b/source/UrlConn.pas
@@ -1062,7 +1062,7 @@ begin
     Thread := FWaiting[Index];
     Thread.Terminate;
     if Thread.Suspended then
-      Thread.Resume;
+      Thread.Suspended := False;
   end;
 
   for Index := FRunning.Count - 1 downto 0 do
@@ -1070,7 +1070,7 @@ begin
     Thread := FRunning[Index];
     Thread.Terminate;
     if Thread.Suspended then
-      Thread.Resume;
+      Thread.Suspended := False
   end;
 
   while (FWaiting.Count > 0) or (FRunning.Count > 0) do
@@ -1143,7 +1143,7 @@ begin
     Thread := FWaiting[0];
     FWaiting.Delete(0);
     FRunning.Add(Thread);
-    Thread.Resume;
+    Thread.Suspended := False
   end;
 end;
 

--- a/source/UrlConn.pas
+++ b/source/UrlConn.pas
@@ -811,7 +811,7 @@ begin
 
         Text.Add('<tbody>');
         repeat
-{$ifndef TSearchRecHasNoTimestamp}
+{$ifdef TSearchRecHasNoTimestamp}
             TimeStamp := FileDateToDateTime(F.Time);
 {$else}
             TimeStamp := F.TimeStamp;

--- a/source/htmlcons.inc
+++ b/source/htmlcons.inc
@@ -125,6 +125,14 @@
                                    {$define Compiler30_Plus}
                                    {$ifdef ver300}
                                    {$else}
+                                     {$define Compiler31_Plus}
+                                     {$ifdef ver310}
+                                     {$else}
+                                       {$define Compiler32_Plus}
+                                       {$ifdef ver320}
+                                       {$else}
+                                       {$endif}
+                                     {$endif}
                                    {$endif}
                                  {$endif}
                                {$endif}

--- a/source/htmlgif1.pas
+++ b/source/htmlgif1.pas
@@ -1964,7 +1964,7 @@ begin
 
     IntfImage.CreateBitmaps(ImgHandle, MskHandle);
     DeleteObject(ImgHandle);
-    Bitmap.Mask.BitmapHandle := MskHandle;
+    Bitmap.BitmapMask.BitmapHandle := MskHandle;
   finally
     IntfImage.Free;
     //Bitmap.Free;
@@ -2150,12 +2150,12 @@ begin
     if IsTransparent then
     begin
       Result.HandleType := bmDIB;
-      Result.Mask.LoadFromStream(MStream);
+      Result.BitmapMask.LoadFromStream(MStream);
 {$ifdef LCL}
       // setting to monochrome not yet implemented
       CreateMask(Result, clWhite);
 {$else}
-      Result.Mask.Monochrome := True; {crunch mask into a monochrome TBitmap}
+      Result.BitmapMask.Monochrome := True; {crunch mask into a monochrome TBitmap}
 {$endif}
     end;
     Stream.Free;

--- a/source/htmlview.pas
+++ b/source/htmlview.pas
@@ -4777,7 +4777,7 @@ function THtmlViewer.GetSelHtml: UTF8String;
       LTML: ThtString;
       C: ThtChar;
     begin
-      C := #0; // valium for Delphi 2009+
+      {$IFNDEF Compiler32_Plus}C := #0;{$ENDIF} // valium for Delphi 2009+
       LTML := htLowerCase(HTML);
       repeat
         I := Pos(Tag, LTML);


### PR DESCRIPTION
* Extended compiler defines for Ver310 and 320
* Contains a breaking change in ThtBitmap, as property Mask has had to be renamed
* One ToDo added
* Compatibility with Lazarus not yet tested