### PR TITLE
Fix missing focus on links in Delphi

### DIFF
--- a/source/HTMLSubs.pas
+++ b/source/HTMLSubs.pas
@@ -13451,6 +13451,7 @@ var
             ARect := Rect(CPx, Tmp - FO.FontHeight, CP1x + 1, Tmp);
             if FO.Active then
             begin
+              Canvas.Brush.Color := clWhite;
               Canvas.Font.Color := clBlack; {black font needed for DrawFocusRect}
               Canvas.Handle; {Dummy call needed to make Delphi add font color change to handle}
               if Document.TheOwner.ShowFocusRect then //MK20091107


### PR DESCRIPTION
With Delphi Seattle (10.1), Berlin (10.2), and Rio (10.3) focus rectangles aren't being drawn for anchors such as:
```<a href="test">Test</a>```

A quick look at the code I discovered that the other spots that draw focus rectangles set the _brush_ color to `clWhite` before calling `Canvas.DrawFocusRect`.  The code in HTMLSubs.pas does not and instead sets the _font_ color to clBlack.  My fix is simply to add this code prior to drawing the focus rectangle:

```Canvas.Brush.Color := clWhite;```
