### PR TITLE
Fixed cursor using hourglass instread of LoadCursor

### DIFF
--- a/source/htmlview.pas
+++ b/source/htmlview.pas
@@ -2660,9 +2660,14 @@ begin
     Exit;
   if Value <> FSectionList.ShowImages then
   begin
-    OldCursor := Screen.Cursor;
+    if LoadCursor <> crDefault then
+    begin
+      OldCursor := Screen.Cursor;
+      Screen.Cursor := LoadCursor;
+    end
+    else
+      OldCursor := crDefault; // valium for the compiler
     try
-      Screen.Cursor := crHourGlass;
       SetProcessing(True);
       FSectionList.ShowImages := Value;
       if FSectionList.Count > 0 then


### PR DESCRIPTION
When loading images in lists, the cursor is changing from the loadcursor image to the hourglass.  This  makes it flash a lot when loading a list of images.  Change makes it use the LoadCursor property instead.