### PR TITLE
closes #139; black square in Lazarus designer

### DIFF
--- a/source/htmlview.pas
+++ b/source/htmlview.pas
@@ -879,6 +879,10 @@ begin
   FPaintPanel.Parent := FBorderPanel; //Self;
   FPaintPanel.BevelOuter := bvNone;
   FPaintPanel.BevelInner := bvNone;
+{$ifdef LCL}
+	FPaintPanel.Align := alClient; // MV, 20.12.2020: issue 139. paint panel should fill available htmlviewer area
+	FPaintPanel.Color := DefBackground; // MV, 20.12.2020: issue 139. paint panel should accept default background color
+{$endif}
 {$ifndef LCL}
   FPaintPanel.Ctl3D := False;
 {$endif}


### PR DESCRIPTION

![HtmlViewer Issue 139](https://user-images.githubusercontent.com/937586/102719181-910f9580-42ba-11eb-92ff-085966fdab14.png)
Force THtmlViewer FPaintPanel to fill available viewer area and accept specified DefBackground color in Lazarus designer; closes #139