### PR TITLE
Fixed: unit name is not found in Linux

### DIFF
--- a/source/framview.pas
+++ b/source/framview.pas
@@ -42,7 +42,7 @@ uses
   HtmlGlobals,
   HtmlBuffer,
   HtmlImages, 
-  Htmlsubs,
+  HTMLSubs,
   Htmlview,
   HtmlSymb,
   HTMLUn2,


### PR DESCRIPTION
Hi, I've just changed only the capitalization of the unit name as fpc under linux is not able to locate the unit.

Domenico