### PR TITLE
Add html_dots_per_inch variable to HtmlFonts

### DIFF
--- a/source/HtmlFonts.pas
+++ b/source/HtmlFonts.pas
@@ -116,6 +116,10 @@ type
 
 function AllMyFonts: ThtFontCache;
 
+var
+  // Added for Templot compatibility - controls HTML rendering DPI
+  html_dots_per_inch: Integer;
+
 implementation
 
 var


### PR DESCRIPTION
## Summary
- Adds a public `html_dots_per_inch: Integer` variable to the `HtmlFonts` unit
- Allows applications to control the DPI used for HTML rendering/scaling

## Use case
Templot (model railway track design software) uses the HtmlViewer component
to display help pages. This variable lets users adjust text scaling for
different display sizes and resolutions.

## Changes
- `source/HtmlFonts.pas`: Added `html_dots_per_inch` variable in the interface section

This is a minimal, non-breaking addition — existing code is unaffected since
the variable defaults to 0 and is only used if explicitly set by the application.